### PR TITLE
Convert slideshow to multi-page static site and add GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,37 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: ["main", "master", "work"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey t
 I'll meet you over there, can't wait to get started!
 
 This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
+
+## Personal website deployment on GitHub
+
+This repository now contains a static personal website with these pages:
+- `index.html` (Home)
+- `research.html`
+- `teaching.html`
+
+To publish on GitHub Pages:
+1. Push to your default branch.
+2. In GitHub, open **Settings → Pages**.
+3. Set **Build and deployment** source to **GitHub Actions**.
+4. The included workflow `.github/workflows/deploy-pages.yml` will deploy automatically.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,72 @@
+:root {
+  --bg: #f4f7fb;
+  --card: #ffffff;
+  --text: #14213d;
+  --accent: #0b5ed7;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: Inter, "Segoe UI", Roboto, Arial, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+.hero,
+.subhead {
+  background: linear-gradient(135deg, #0d1b2a, #1b263b);
+  color: #fff;
+  padding: 1rem 1.5rem;
+}
+
+.hero { padding-bottom: 3rem; }
+
+.nav {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand { color: #fff; font-weight: 700; text-decoration: none; }
+
+.nav-links { display: flex; gap: 1rem; flex-wrap: wrap; }
+
+.nav-links a { color: #dbe8ff; text-decoration: none; }
+.nav-links a.active { color: #fff; border-bottom: 2px solid #fff; }
+
+.hero-content { max-width: 1000px; margin: 3rem auto 0; }
+h1, h2, h3 { line-height: 1.25; }
+
+.btn {
+  display: inline-block;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid #c4d9ff;
+  color: #fff;
+  text-decoration: none;
+}
+
+.btn.primary { background: var(--accent); border-color: var(--accent); }
+.hero-actions { display: flex; gap: 0.75rem; margin-top: 1rem; flex-wrap: wrap; }
+
+.section,
+.footer {
+  max-width: 1000px;
+  margin: 1.5rem auto;
+  padding: 1.5rem;
+  border-radius: 14px;
+  background: var(--card);
+  box-shadow: 0 10px 30px rgba(10, 30, 90, 0.08);
+}
+
+a { color: var(--accent); }
+
+@media (max-width: 700px) {
+  .nav { flex-direction: column; align-items: flex-start; }
+}

--- a/index.html
+++ b/index.html
@@ -1,13 +1,52 @@
----
-layout: presentation
----
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sumit Saurav | Home</title>
+    <meta name="description" content="Home page of Sumit Saurav: Assistant Professor at IIM Bangalore." />
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body>
+    <header class="hero" id="home">
+      <nav class="nav">
+        <a class="brand" href="index.html">Sumit Saurav</a>
+        <div class="nav-links">
+          <a class="active" href="index.html">Home</a>
+          <a href="research.html">Research</a>
+          <a href="teaching.html">Teaching</a>
+          <a href="#contact">Contact</a>
+        </div>
+      </nav>
 
-{% for post in site.posts reversed %}
-	{% include slide.html %}
-	<div class="page-break"></div>
-{% endfor %}
-{% unless site.simple-slideshow %}
-{% if site.overview %}
-<section id="overview" class="step" {% for attr in site.overview-data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}></section>
-{% endif %}
-{% endunless %}
+      <div class="hero-content">
+        <h1>Sumit Saurav</h1>
+        <p>I am an Assistant Professor in the Finance and Accounting Area (F&amp;A) at the Indian Institute of Management Bangalore.</p>
+        <p>My research interests are in Asset Pricing, Options, Banking, and Economics of Regulation.</p>
+        <div class="hero-actions">
+          <a class="btn primary" href="https://drive.google.com/file/d/19l6YqhWyXA_LMgUlRx5mkF_AWWPj53NI/view?usp=sharing" target="_blank" rel="noopener noreferrer">Curriculum Vitae</a>
+          <a class="btn" href="research.html">View Research</a>
+        </div>
+      </div>
+    </header>
+
+    <main class="section">
+      <h2>Quick Links</h2>
+      <ul>
+        <li><a href="research.html">Research profile, working papers, and publications</a></li>
+        <li><a href="teaching.html">MBA and PhD teaching information</a></li>
+      </ul>
+    </main>
+
+    <footer id="contact" class="footer">
+      <h2>Contact</h2>
+      <p>Email: <a href="mailto:sumit.saurav@iimb.ac.in">sumit.saurav@iimb.ac.in</a></p>
+      <p>
+        Other websites:
+        <a href="http://www.linkedin.com/in/sumit-saurav-b0028643/?originalSubdomain=in" target="_blank" rel="noopener noreferrer">LinkedIn</a>,
+        <a href="http://scholar.google.com/citations?user=W3MPRP4AAAAJ&hl=en" target="_blank" rel="noopener noreferrer">Google Scholar</a>,
+        <a href="http://www.researchgate.net/profile/Sumit-Saurav-2" target="_blank" rel="noopener noreferrer">ResearchGate</a>
+      </p>
+    </footer>
+  </body>
+</html>

--- a/research.html
+++ b/research.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sumit Saurav | Research</title>
+    <meta name="description" content="Research page of Sumit Saurav with working papers and publications." />
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body>
+    <header class="subhead">
+      <nav class="nav">
+        <a class="brand" href="index.html">Sumit Saurav</a>
+        <div class="nav-links">
+          <a href="index.html">Home</a>
+          <a class="active" href="research.html">Research</a>
+          <a href="teaching.html">Teaching</a>
+          <a href="#contact">Contact</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="section">
+      <h1>Research</h1>
+
+      <h2>Working Papers</h2>
+      <ul>
+        <li>Impact of Embedded Leverage on Trading Activity in Stock, Options, and Futures Markets, with Sobhesh Kumar Agarwalla (IIM-A), and Jayanth R. Varma (IIM-A).</li>
+        <li>Effect of Continuous Disclosure Requirement on Information Leakage Around Earnings Announcements, with Sobhesh Kumar Agarwalla (IIM-A), Ajay Pandey (IIM-A), and Jayanth R. Varma (IIM-A).</li>
+        <li>Natural Disasters, Interest Rate Dynamics, and Economic Activities, with Abhiman Das (IIM-A), and Tanmoy Majilla (IIM-A).</li>
+        <li>Bankruptcy codes and asymmetric cost behaviour, with Debojyoti Das, and Arun Upadhyay.</li>
+      </ul>
+
+      <h2>Published/Forthcoming Papers (Peer-Reviewed)</h2>
+      <ul>
+        <li>Lottery and bubble stocks and the cross-section of option-implied tail risks, with Sobhesh Kumar Agarwalla, and Jayanth R. Varma, <em>Journal of Futures Market</em>, 42 (2), 231-249.</li>
+        <li>Belief distortion near 52 Week High and Low: Evidence from Indian equity options market, with Sobhesh Kumar Agarwalla, and Jayanth R. Varma, <em>Journal of Futures Market</em>, 43 (11), 1531-1558.</li>
+        <li>Role of derivatives market in attenuating underreaction to left-tail risk, with Sobhesh Kumar Agarwalla, and Jayanth R. Varma, <em>Journal of Futures Market</em>, 44 (3), 484-517.</li>
+        <li>Asymmetric uncertainty around earnings announcements: Evidence from options market, with Sobhesh Kumar Agarwalla, and Jayanth R. Varma, <em>American Business Review</em>, Vol. 27, No. 2, Article 4.</li>
+        <li>Does Government Ownership Differently Impact Expected Left-Tail and Volatility Risk of Bank Stock? Evidence from Options Market, with Pranjal Srivastava, and Abinash Mishra, <em>Journal of Corporate Finance</em> (2025), 102832.</li>
+        <li>Modelling for insight: Does oil price uncertainty have directional predictability for travel and leisure firms?, with Debojyoti Das and Anupam Dutta, <em>Energy Economics</em> (Forthcoming).</li>
+      </ul>
+
+      <h2>Media Articles</h2>
+      <p>Article on the effectiveness of the Repo rate as policy rate in a surplus liquidity condition (published on July 31, 2020 in <em>The Hindu Business Line</em>) with Pranjal Srivastava (PhD student, IIM-A).</p>
+
+      <h2>Book Chapters</h2>
+      <p>Saurav, S. (2020). Review of Corporate Governance in Emerging Economies from the Perspective of Principal-Principal Conflict. <em>The Financial Landscape of Emerging Economies</em>, 111-121.</p>
+    </main>
+
+    <footer id="contact" class="footer">
+      <h2>Contact</h2>
+      <p>Email: <a href="mailto:sumit.saurav@iimb.ac.in">sumit.saurav@iimb.ac.in</a></p>
+    </footer>
+  </body>
+</html>

--- a/teaching.html
+++ b/teaching.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sumit Saurav | Teaching</title>
+    <meta name="description" content="Teaching page of Sumit Saurav." />
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body>
+    <header class="subhead">
+      <nav class="nav">
+        <a class="brand" href="index.html">Sumit Saurav</a>
+        <div class="nav-links">
+          <a href="index.html">Home</a>
+          <a href="research.html">Research</a>
+          <a class="active" href="teaching.html">Teaching</a>
+          <a href="#contact">Contact</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="section">
+      <h1>Teaching</h1>
+      <h2>MBA</h2>
+      <ul>
+        <li>Corporate Finance (PGP Core Course)</li>
+        <li>Investment Management (PGP Term III Elective)</li>
+      </ul>
+
+      <h2>PhD</h2>
+      <ul>
+        <li>Indian Financial Markets and Institutions</li>
+      </ul>
+    </main>
+
+    <footer id="contact" class="footer">
+      <h2>Contact</h2>
+      <p>Email: <a href="mailto:sumit.saurav@iimb.ac.in">sumit.saurav@iimb.ac.in</a></p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Replace the reveal.js slideshow with a simple, maintainable multi-page static site that preserves the original Google Site content and improves navigation for visitors. 
- Provide a straightforward deployment path so the site can be published via GitHub Pages using Actions.

### Description
- Added separate pages `index.html`, `research.html`, and `teaching.html` that retain content while enabling page-specific active navigation state. 
- Introduced shared styling in `assets/styles.css` to provide a responsive hero/subhead, consistent layout, and active-link highlighting across pages. 
- Added a GitHub Pages Actions workflow at `.github/workflows/deploy-pages.yml` to publish the repository as a Pages site. 
- Updated `README.md` with concise instructions for enabling GitHub Pages and the included workflow, and added a CV link and quick-links from the home page.

### Testing
- Served the site locally with `python3 -m http.server 8000` and confirmed pages loaded successfully. 
- Ran an automated Playwright script that opened `index.html` and `research.html` and produced full-page screenshots, which completed successfully and produced artifacts. 
- Verified the new Pages workflow file exists in the repository (workflow has not been executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4d4dd8e4832a8e1eb52da3787ffc)